### PR TITLE
README.md: remove libcrush.org references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 libcrush is a C library to control placement in a hierarchy
 
-The API documentation is at http://doc.libcrush.org/master/group___a_p_i.html
-
-The full documentation is at http://libcrush.org/main/libcrush/wikis/home
-
 The sources of crush were extracted from Ceph on January 2017 and are
 licensed under LGPL-2.1 (see LICENSE-LGPL-2.1 for the full text of the
 license).


### PR DESCRIPTION
Domain has expired and since been pwned.

Signed-off-by: Sage Weil <sage@redhat.com>